### PR TITLE
Support categorical features with identities

### DIFF
--- a/nvtabular/framework_utils/tensorflow/feature_column_utils.py
+++ b/nvtabular/framework_utils/tensorflow/feature_column_utils.py
@@ -103,6 +103,7 @@ def make_feature_column_workflow(feature_columns, label_name, category_dir=None)
 
     _CATEGORIFY_COLUMNS = (fc.VocabularyListCategoricalColumn, fc.VocabularyFileCategoricalColumn)
     categorifies, hashes, crosses, buckets, replaced_buckets = {}, {}, {}, {}, {}
+    identities = []
 
     numeric_columns = []
     new_feature_columns = []
@@ -191,6 +192,7 @@ def make_feature_column_workflow(feature_columns, label_name, category_dir=None)
 
         elif isinstance(cat_column, fc.IdentityCategoricalColumn):
             new_feature_columns.append(column)
+            identities.append(cat_column)
             continue
 
         else:
@@ -278,6 +280,9 @@ def make_feature_column_workflow(feature_columns, label_name, category_dir=None)
 
     if numeric_columns:
         features += [col.key for col in numeric_columns]
+
+    if identities:
+        features += [col.key for col in identities]
 
     workflow = nvt.Workflow(features)
 

--- a/tests/unit/test_tf_feature_columns.py
+++ b/tests/unit/test_tf_feature_columns.py
@@ -18,7 +18,10 @@ def test_feature_column_utils():
             ),
             32,
         ),
+        tf.feature_column.indicator_column(
+            tf.feature_column.categorical_column_with_identity("vocab_3", 10),
+        ),
     ]
 
     workflow, _ = nvtf.make_feature_column_workflow(cols, "target")
-    assert workflow.column_group.columns == ["target", "vocab_1", "vocab_2"]
+    assert workflow.column_group.columns == ["target", "vocab_1", "vocab_2", "vocab_3"]


### PR DESCRIPTION
Add support for categorical features with identities to `make_feature_column_workflow` to make it include such columns into the generated workflow object.

Example of a feature column with identity is below. Currently `make_feature_column_workflow` doesn't add such columns to the workflow object but adds them to the generated list of feature columns, making model training fail due to the column missing in the workflow definition.
```
feature_column = fc.indicator_column(
        fc.categorical_column_with_identity(
            key=feat_name, num_buckets=num_categories, default_value=default_value
        )
    )
```