### PR TITLE
Make make_feature_column_workflow work with vocabularies of varying sizes

### DIFF
--- a/nvtabular/framework_utils/tensorflow/feature_column_utils.py
+++ b/nvtabular/framework_utils/tensorflow/feature_column_utils.py
@@ -226,7 +226,8 @@ def make_feature_column_workflow(feature_columns, label_name, category_dir=None)
         features += features_replaced_buckets
 
     if len(categorifies) > 0:
-        features += categorifies.keys() >> Categorify(vocabs=pd.DataFrame(categorifies))
+        vocabs = {column: pd.Series(vocab) for column, vocab in categorifies.items()}
+        features += categorifies.keys() >> Categorify(vocabs=vocabs)
 
     if len(hashes) > 0:
         features += hashes.keys() >> HashBucket(hashes)

--- a/nvtabular/ops/categorify.py
+++ b/nvtabular/ops/categorify.py
@@ -333,26 +333,26 @@ class Categorify(StatOperator):
     def process_vocabs(self, vocabs):
         categories = {}
 
-        if dispatch._is_dataframe_object(vocabs):
-            fit_options = self._create_fit_options_from_columns(list(vocabs.columns))
+        if isinstance(vocabs, dict) and all(dispatch._is_series_object(v) for v in vocabs.values()):
+            fit_options = self._create_fit_options_from_columns(list(vocabs.keys()))
             base_path = os.path.join(self.out_path, fit_options.stat_name)
             os.makedirs(base_path, exist_ok=True)
-            for col in list(vocabs.columns):
-                col_df = vocabs[[col]]
-                if col_df[col].iloc[0] is not None:
-                    with_empty = dispatch._add_to_series(col_df[col], [None]).reset_index()[0]
+            for col, vocab in vocabs.items():
+                vals = {col: vocab}
+                if vocab.iloc[0] is not None:
+                    with_empty = dispatch._add_to_series(vocab, [None]).reset_index()[0]
                     vals = {col: with_empty}
-                    col_df = dispatch._make_df(vals)
 
                 save_path = os.path.join(base_path, f"unique.{col}.parquet")
+                col_df = dispatch._make_df(vals)
                 col_df.to_parquet(save_path)
                 categories[col] = save_path
         elif isinstance(vocabs, dict) and all(isinstance(v, str) for v in vocabs.values()):
             categories = vocabs
         else:
             error = """Unrecognized vocab type,
-            please provide either a dictionary with paths to a parquet files
-            or a DataFrame that contains the vocabulary per column.
+            please provide either a dictionary with paths to parquet files
+            or a dictionary with pandas Series objects.
             """
             raise ValueError(error)
 

--- a/tests/unit/test_ops.py
+++ b/tests/unit/test_ops.py
@@ -470,7 +470,7 @@ def test_lambdaop_misalign(cpu):
 @pytest.mark.parametrize("freq_threshold", [0, 1, 2])
 @pytest.mark.parametrize("cpu", _CPU)
 @pytest.mark.parametrize("dtype", [None, np.int32, np.int64])
-@pytest.mark.parametrize("vocabs", [None, pd.DataFrame({"Authors": [f"User_{x}" for x in "ACBE"]})])
+@pytest.mark.parametrize("vocabs", [None, {"Authors": pd.Series([f"User_{x}" for x in "ACBE"])}])
 def test_categorify_lists(tmpdir, freq_threshold, cpu, dtype, vocabs):
     df = dispatch._make_df(
         {

--- a/tests/unit/test_tf_feature_columns.py
+++ b/tests/unit/test_tf_feature_columns.py
@@ -14,7 +14,7 @@ def test_feature_column_utils():
         ),
         tf.feature_column.embedding_column(
             tf.feature_column.categorical_column_with_vocabulary_list(
-                "vocab_2", ["1", "2", "3", "4"]
+                "vocab_2", ["1", "2", "3", "4", "5"]
             ),
             32,
         ),


### PR DESCRIPTION
`make_feature_column_workflow` fails in `Categorify` if features have vocabularies of varying sizes. This fix changes the type of parameter `vocabs` of `Categorify` to be a dictionary instead of `DataFrame` so that clients can provide dictionaries of varying sizes.

This fixes https://github.com/NVIDIA/NVTabular/issues/1062.