### PR TITLE
Fix bucketized feature columns handling in make_feature_column_workflow

### DIFF
--- a/nvtabular/framework_utils/tensorflow/feature_column_utils.py
+++ b/nvtabular/framework_utils/tensorflow/feature_column_utils.py
@@ -146,9 +146,9 @@ def make_feature_column_workflow(feature_columns, label_name, category_dir=None)
             # boundaries and embedding dim so that we can wrap
             # with either indicator or embedding later
             if key in [col.key for col in numeric_columns]:
-                buckets[key] = (column.boundaries, embedding_dim)
+                buckets[key] = (cat_column.boundaries, embedding_dim)
             else:
-                replaced_buckets[key] = (column.boundaries, embedding_dim)
+                replaced_buckets[key] = (cat_column.boundaries, embedding_dim)
 
             # put off dealing with these until the end so that
             # we know whether we need to replace numeric

--- a/tests/unit/test_tf_feature_columns.py
+++ b/tests/unit/test_tf_feature_columns.py
@@ -6,6 +6,19 @@ nvtf = pytest.importorskip("nvtabular.framework_utils.tensorflow")
 
 def test_feature_column_utils():
     cols = [
+        tf.feature_column.bucketized_column(
+            tf.feature_column.numeric_column(
+                "bucketized_1",
+            ),
+            [0, 10, 100],
+        ),
+        tf.feature_column.embedding_column(
+            tf.feature_column.bucketized_column(
+                tf.feature_column.numeric_column("bucketized_2"),
+                [0, 100, 500],
+            ),
+            64,
+        ),
         tf.feature_column.embedding_column(
             tf.feature_column.categorical_column_with_vocabulary_list(
                 "vocab_1", ["a", "b", "c", "d"]
@@ -21,4 +34,10 @@ def test_feature_column_utils():
     ]
 
     workflow, _ = nvtf.make_feature_column_workflow(cols, "target")
-    assert workflow.column_group.columns == ["target", "vocab_1", "vocab_2"]
+    assert workflow.column_group.columns == [
+        "target",
+        "bucketized_1",
+        "bucketized_2",
+        "vocab_1",
+        "vocab_2",
+    ]


### PR DESCRIPTION
`make_feature_column_workflow` fails to handle the case when an embedding is built based on a bucketized feature columns, as it attempts to take buckets boundaries from a wrong object (`column` instead of `cat_column`).